### PR TITLE
html_export_with_paragraphs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.danielluedecke</groupId>
     <artifactId>Zettelkasten</artifactId>
-    <version>3.2025.11</version>
+    <version>3.2025.12</version>
     <name>Zettelkasten</name>
     <properties>
         <zkn.launch4jVersion>${project.version}.0</zkn.launch4jVersion>
@@ -356,6 +356,12 @@
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf</artifactId>
             <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <!-- jsoup HTML parser library @ https://jsoup.org/ -->
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.21.2</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/java/de/danielluedecke/zettelkasten/tasks/export/ExportToHtmlTask.java
+++ b/src/main/java/de/danielluedecke/zettelkasten/tasks/export/ExportToHtmlTask.java
@@ -573,10 +573,9 @@ public class ExportToHtmlTask extends org.jdesktop.application.Task<Object, Void
                 // get the zettelcontent
                 String zettelcontent = dataObj.getZettelContent(zettelnummer, true).replace("<", "&lt;").replace(">", "&gt;");
                 // init paragraph with class-attribute, so the user may change style aftwerwards
-                // original
+                // original, currently inactivated
                 //sb.append("<p class=\"zettelcontent\">");
                 // test for replacement of <br> with <p>, see HtmlUbbUtil
-                sb.append("<p class=\"zettelcontent\"/>");
                 // if we have content, add it.
                 if (!zettelcontent.isEmpty()) {
                     /*
@@ -600,10 +599,8 @@ public class ExportToHtmlTask extends org.jdesktop.application.Task<Object, Void
                     // else add remark that entry is deleted
                     sb.append("<i>").append(resourceMap.getString("deletedEntry")).append("</i>").append(System.lineSeparator());
                 }
-                // original
+                // original, currently inactivated
                 //sb.append("</p>");
-                // empty string to test replacement of <br> with paragrafs, see HtmlUbbUtil UbbToHtml
-                sb.append("");
             }
             // if the user wants to export remarks, do this here.
             if ((exportparts & Constants.EXPORT_REMARKS) != 0) {


### PR DESCRIPTION
On export to HTML, paragraphs get tagged with proper <p> and </p> markup. This improves import into LibreOffice, too.